### PR TITLE
docs(deploy): accept any git ref in deploy.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,12 +217,21 @@ times out on ACME challenges. See `docs/plans/tls-debugging.md` for details.
 ### Updating
 
 ```bash
-# Pull latest image and restart
+# Go into the production bonanza folder
+cd /opt/bonanza
+
+# Alter the desired IMAGE_TAG environment variable
+# See https://hub.docker.com/repository/docker/bonanzahq/bonanza/tags
+# for current tags. Don't use main, latest or beta in production
+vim .env
+
+# Pull changed image and restart
 docker compose pull
 docker compose up -d
 
 # Re-download config files if changed upstream
-bash deploy.sh
+# deploy.sh accepts any git ref: branch, tag, or SHA (e.g. v2.1.2, beta)
+bash deploy.sh v2.1.2
 ```
 
 ## GDPR Compliance

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ABOUTME: Downloads deployment files from GitHub for a given branch.
+# ABOUTME: Downloads deployment files from GitHub for a given git ref.
 # ABOUTME: Run once to set up, then fill in .env and start with docker compose.
 
 set -euo pipefail
@@ -7,16 +7,18 @@ set -euo pipefail
 REPO="bonanzahq/bonanza"
 
 usage() {
-  echo "Usage: ./deploy.sh [branch]"
+  echo "Usage: ./deploy.sh [ref]"
   echo ""
   echo "Downloads docker-compose.yml, Caddyfile, and other deployment files"
-  echo "from the specified branch (default: main)."
+  echo "from the specified git ref (default: main). Accepts branches, tags,"
+  echo "or commit SHAs."
   echo ""
   echo "Requires GITHUB_TOKEN in the environment or .env file."
   echo ""
   echo "Examples:"
   echo "  ./deploy.sh          # pull from main"
-  echo "  ./deploy.sh beta     # pull from beta"
+  echo "  ./deploy.sh beta     # pull from beta branch"
+  echo "  ./deploy.sh v2.1.2   # pull from a tag"
   exit 0
 }
 
@@ -32,8 +34,8 @@ if [ -z "${GITHUB_TOKEN:-}" ]; then
   exit 1
 fi
 
-BRANCH="${1:-main}"
-BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}"
+REF="${1:-main}"
+BASE_URL="https://raw.githubusercontent.com/${REPO}/${REF}"
 
 # Validate token
 if ! curl -fsSL -o /dev/null -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPO}" 2>/dev/null; then
@@ -41,13 +43,13 @@ if ! curl -fsSL -o /dev/null -H "Authorization: token ${GITHUB_TOKEN}" "https://
   exit 1
 fi
 
-# Validate branch exists
+# Validate ref exists
 if ! curl -fsSL -o /dev/null -H "Authorization: token ${GITHUB_TOKEN}" "${BASE_URL}/docker/docker-compose.yml" 2>/dev/null; then
-  echo "Error: branch '${BRANCH}' not found or docker/docker-compose.yml missing on that branch"
+  echo "Error: ref '${REF}' not found or docker/docker-compose.yml missing at that ref"
   exit 1
 fi
 
-echo "Downloading deployment files from ${REPO}:${BRANCH}..."
+echo "Downloading deployment files from ${REPO}:${REF}..."
 
 curl -fsSL -H "Authorization: token ${GITHUB_TOKEN}" "${BASE_URL}/docker/docker-compose.yml" -o docker-compose.yml
 echo "  docker-compose.yml"
@@ -70,7 +72,7 @@ if [ ! -f .env ]; then
 fi
 
 echo ""
-echo "Done. Files pulled from '${BRANCH}'."
+echo "Done. Files pulled from '${REF}'."
 echo ""
 echo "Next steps:"
 echo "1. Edit .env and fill in all required values (see example.env for reference)"


### PR DESCRIPTION
## Summary
- Rename `BRANCH` variable to `REF` in deploy.sh to reflect that it already accepts branches, tags, and commit SHAs
- Update usage text and examples to show tag usage (e.g. `./deploy.sh v2.1.2`)
- Expand README update instructions with full production workflow

## Test plan
- [x] Verify `./deploy.sh --help` shows updated usage
- [x] Verify `./deploy.sh v2.1.2` works with a valid tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)